### PR TITLE
Fixed dereferencing for YAML format.

### DIFF
--- a/dereference.js
+++ b/dereference.js
@@ -32,7 +32,8 @@ $RefParser.dereference(input, { resolve: { s3: s3Resolver } }, function(err, sch
       fs.writeFileSync(output, data, { encoding: 'utf8', flag: 'w' });
     } else if (ext.match(/^\.?(yaml|yml)$/)) {
       var yaml = require('node-yaml');
-      yaml.writeSync(output, schema, { encoding: 'utf8' })
+      var data = yaml.dump(schema, { encoding: 'utf8', noRefs: true });
+      fs.writeFileSync(output, data, { encoding: 'utf8', flag: 'w' });
     } else {
       console.error("Unrecognised output file type: " + output);
       process.exit(1);


### PR DESCRIPTION
One solution for this problem would be to use the `dump` function of the `node-yaml` wrapper, which accepts the `noRefs` parameter and passes it through to the `js-yaml` parser that is responsible for the actual conversion and re-referencing.